### PR TITLE
添加Giscus评论

### DIFF
--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -42,10 +42,13 @@ export default hopeTheme({
   },
 
   plugins: {
-    // comment: {
-    //   // @ts-expect-error: You should generate and use your own comment service
-    //   provider: "Waline",
-    // },
+    comment: {
+      provider: "Giscus",
+      repo: "zotero-chinese/.github",
+      repoId: "R_kgDOHv4ukA",
+      category: "文档评论区",
+      categoryId: "DIC_kwDOHv4ukM4CZz7S",
+    },
 
     // all features are enabled for demo, only preserve features you need here
     mdEnhance: {

--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -30,7 +30,7 @@ export default hopeTheme({
       sidebar: zhSidebar,
 
       footer:
-        "Zotero 中文小组 | <a href='/contributing/'>贡献指南</a> | <a href='/'>参与讨论</a> | <a href='/'>加入 QQ 群组</a>",
+        "Zotero 中文小组 | <a href='/contributing/'>贡献指南</a> | <a href='https://github.com/orgs/zotero-chinese/discussions'>参与讨论</a> | <a href='/'>加入 QQ 群组</a>",
 
       displayFooter: true,
 

--- a/src/contributing/contributing.md
+++ b/src/contributing/contributing.md
@@ -22,8 +22,8 @@ Zotero 中文文档接受多种形式的贡献，请阅读这一份指南，以�
 参与文档的维护的主要方式：
 
 1. 在 GitHub 上的文档源码仓库下 [提交 ISSUE](https://github.com/zotero-chinese/wiki/issues)
-2. 在 GitHub 上的文档源码仓库下的 Discussions 上留言（也可以直接点击文档网页底部的“参与讨论”）
-3. ~~在网页底部评论区留言~~ (暂未上线)
+2. 在 GitHub Zotero Chinese 组织的 [Discussions 上讨论](https://github.com/orgs/zotero-chinese/discussions)（也可以直接点击文档网页底部的“参与讨论”）
+3. 在网页底部评论区留言
 4. 修改文档源码并提交 Pull Request （不熟悉 Pull Request 的读者可以参考 Pull Request 流程）
 
 ## 提交 / 参与议题 / 讨论


### PR DESCRIPTION
添加 Giscus 作为评论系统，zotero-chinese/.github 仓库作为 discussion 存储仓库，该仓库也默认为组织的 discussion 仓库: https://github.com/orgs/zotero-chinese/discussions 。

分类为`文档评论区`，该分类仅允许机器人和管理员创建/删除讨论，以保护数据。