### PR TITLE
修改评论区内容存储仓库

### DIFF
--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -47,10 +47,10 @@ export default hopeTheme({
   plugins: {
     comment: {
       provider: "Giscus",
-      repo: "zotero-chinese/.github",
-      repoId: "R_kgDOHv4ukA",
+      repo: "zotero-chinese/wiki",
+      repoId: "R_kgDOJZD4iQ",
       category: "文档评论区",
-      categoryId: "DIC_kwDOHv4ukM4CZz7S",
+      categoryId: "DIC_kwDOJZD4ic4CbJJB",
     },
 
     // all features are enabled for demo, only preserve features you need here


### PR DESCRIPTION
【方案处于讨论中】

将 discus 的存储仓库从 `.github` 迁移到 `wiki`，有如下考虑：

- .github 仓库访问量/star/watch 都过少
- 读者倾向于在 wiki 创建 issue 来咨询问题等，这类 issue 转为 discussion 时仅能到 wiki 仓库
- 已经 star/watch wiki 仓库的用户在新 discussion 被创建时，可能会收到提醒，有利于提高互动度。

需要等待 `.github` 仓库的 discussion 转移到本仓库才能下一步。