### PR TITLE
Update Zotero-scihub.md 

### DIFF
--- a/src/user-guide/plugins/Zotero-scihub.md
+++ b/src/user-guide/plugins/Zotero-scihub.md
@@ -45,7 +45,7 @@
 
 ::: tip
 
-这种方法在修改 Scihub 地址时较为繁琐，但优点是不会遇到 Scihub 验证码弹窗。
+[这种方法](https://www.zotero.org/support/kb/custom_pdf_resolvers)在修改 Scihub 地址时较为繁琐，但优点是不会遇到 Scihub 验证码弹窗。
 
 当被 Scihub 拒绝时，两种方法都无法抓取文献。
 
@@ -71,12 +71,9 @@
 
    ![同意承担风险](../../assets/image-zotero-findPDFs_resolvers.png)
 
-4. 将下列代码粘贴进去，然后重新启动 Zotero。
-
-   注意：如果原有值是 `[]`，则应该插入到两个中括号之间，而不是直接替换。
-
+4. 将下列代码粘贴进去
    ```json
-   {
+   [{
      "name": "Sci-Hub",
      "method": "GET",
      "url": "https://sci-hub.se/{doi}",
@@ -84,7 +81,30 @@
      "selector": "#pdf",
      "attribute": "src",
      "automatic": true
-   }
+   }]
    ```
 
-   其中`"url":"https://sci-hub.se/{doi}"`, 可以替换为其他的 Scihub 镜像地址。
+   其中`"url":"https://sci-hub.se/{doi}"`, 可以替换为其他的 Sci-Hub 镜像地址。  
+   如果想要从多个 Sci-Hub 地址抓取，按照如下格式添加
+   ```json
+   [{
+     "name": "Sci-Hub",
+     "method": "GET",
+     "url": "https://sci-hub.se/{doi}",
+     "mode": "html",
+     "selector": "#pdf",
+     "attribute": "src",
+     "automatic": true
+    },{
+     "name": "Sci-Hub",
+     "method": "GET",
+     "url": "https://sci-hub.ru/{doi}",
+     "mode": "html",
+     "selector": "#pdf",
+     "attribute": "src",
+     "automatic": true
+   }]
+   ```
+5. 添加上述配置后
+   - 对于新增的项目，Zotero 会自动增加 Sci-Hub 的源抓取 PDF。
+   - 对于已存在的但缺失 PDF 的项目，可以右键点击`查找可用PDF`选项尝试重新抓取。

--- a/src/user-guide/plugins/Zotero-scihub.md
+++ b/src/user-guide/plugins/Zotero-scihub.md
@@ -71,7 +71,7 @@
 
    ![同意承担风险](../../assets/image-zotero-findPDFs_resolvers.png)
 
-4. 将下列代码粘贴进去
+4. 将下列代码粘贴进去直接替换原有内容
    ```json
    [{
      "name": "Sci-Hub",


### PR DESCRIPTION
直接设置`extensions.zotero.findPDFs.resolvers`为数组形式

[Zotero相关逻辑](https://github.com/zotero/zotero/blob/5536f8d2bd08ddac9074b9df05b7d205273835e7/chrome/content/zotero/xpcom/attachments.js#L1350)  

自18年该[feature](https://github.com/zotero/zotero/commit/ce5be0bc754e5bd0c796fd5f02783d2157eb6b9b)首次合入后即有此逻辑，因此无需考虑版本问题