### PR TITLE
替换“插件安装的常见问题”中失效的链接

### DIFF
--- a/src/user-guide/faqs/plugins.md
+++ b/src/user-guide/faqs/plugins.md
@@ -28,5 +28,5 @@ order: 1
 
 ## 插件检查更新时提示未找到更新
 
-可能是确实没有更新，也可能是无法链接到 GitHub。请在插件镜像寻找你需要的安装包：[https://zotero-chinese.gitee.io/zotero-plugins/#/](https://zotero-chinese.gitee.io/zotero-plugins/#/)
+可能是确实没有更新，也可能是无法链接到 GitHub。请在插件商店寻找你需要的安装包：[https://plugins.zotero-chinese.com/#/](https://plugins.zotero-chinese.com/#/)
 即使你能够打开 GitHub 页面，也并不代表 Zotero 能够顺利下载到插件更新。这取决于网络情况。


### PR DESCRIPTION
替换“插件安装的常见问题”中失效的链接
另外这个是不是放到 插件目录 下更合适一下