### PR TITLE
调整“常见问题”分组

### DIFF
--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -85,14 +85,27 @@ export const sidebar = {
         },
         { text: "与 Word 引用相关的", link: "/user-guide/faqs/word-addon" },
         {
-          text: "无法打开“获取更多样式”",
-          link: "/user-guide/faqs/get-more-style-cannot-open",
+          text: "阅读器相关",
+          items: [
+            {
+              text: "PDF 上存在黑色遮罩",
+              link: "/user-guide/faqs/pdf-black-mask",
+            },
+          ],
         },
         {
-          text: "Emoji 变成了黑白的",
-          link: "/user-guide/faqs/monochrome-emoji",
+          text: "其他问题",
+          items: [
+            {
+              text: "无法打开“获取更多样式”",
+              link: "/user-guide/faqs/get-more-style-cannot-open",
+            },
+            {
+              text: "Emoji 变成了黑白的",
+              link: "/user-guide/faqs/monochrome-emoji",
+            },
+          ],
         },
-        { text: "PDF 上存在黑色遮罩", link: "/user-guide/faqs/pdf-black-mask" },
       ],
     },
     {


### PR DESCRIPTION
参考官方文档 (https://www.zotero.org/support/kb#knowledge_base) ，把“常见问题”做个分组，导入条目、引用 这两因为已经是一个合集了，所以不加组，其他的分组。

![image](https://github.com/zotero-chinese/wiki/assets/44738481/499a489a-3a30-45b6-8277-1a19dda9815d)
