### PR TITLE
修改jasminum插件页面教程

### DIFF
--- a/user-guide/plugins/jasminum.md
+++ b/user-guide/plugins/jasminum.md
@@ -38,7 +38,7 @@ MAC 用户参考 [这里](https://github.com/l0o0/jasminum#%E5%A6%82%E4%BD%95%E4
 
 #### 2.2 在茉莉花中配置 PDFtk 路径
 
-在 `Zotero` — `编辑` — `设置` — `茉莉花` — `PDFtk Server 路径设置` 中填写 `<PDFtk install dir>/bin` （例如 `C: \Program Files (x86)\PDFtk\bin`）（即 PDFtk 可执行文件所在目录）。
+在 「Zotero」->「编辑」->「设置」->「茉莉花」->「PDFtk Server 路径设置」中填写 `<PDFtk install dir>/bin` （例如 `C: \Program Files (x86)\PDFtk\bin`）（即 PDFtk 可执行文件所在目录）。
 
 ### 03. 安装/更新 中文 Translator
 

--- a/user-guide/plugins/jasminum.md
+++ b/user-guide/plugins/jasminum.md
@@ -32,7 +32,7 @@
 #### 2.1 下载与安装 PDFtk
 
 **Windows**
-下载并安装 [PDFtk server](https://www.pdflabs.com/tools/pdftk-server/) ，并记录 PDFtk 的安装路径（例如安装在 `C: \Program Files (x86)\PDFtk`）。
+下载并安装 [PDFtk server](https://www.pdflabs.com/tools/pdftk-server/) ，并记录 PDFtk 的安装路径（例如安装在 `C:\Program Files (x86)\PDFtk`）。
 **macOS**
 MAC 用户参考 [这里](https://github.com/l0o0/jasminum#%E5%A6%82%E4%BD%95%E4%BD%BF%E7%94%A8) 。
 

--- a/user-guide/plugins/jasminum.md
+++ b/user-guide/plugins/jasminum.md
@@ -25,9 +25,7 @@
 
 ### 01. 下载安装 Jasminum 插件
 
-在 [茉莉花 - Zotero 插件商店](https://zotero-chinese.com/plugins/#search=jasminum) 下载 `.xpi` 文件，插件安装见 [插件与功能扩展](./about-plugin.md) 。
-
-在 [Zotero 插件商店](https://zotero-chinese.com/plugins/#search=Jasminum) 下载 `Jasminum` ，插件安装见 [插件与功能扩展](./about-plugin.md) 。
+在 [Zotero 插件商店](https://zotero-chinese.com/plugins/#search=Jasminum) 下载 `jasminum` ，插件安装见 [插件与功能扩展](./about-plugin.md) 。
 
 ### 02. 配置 PDFtk
 

--- a/user-guide/plugins/jasminum.md
+++ b/user-guide/plugins/jasminum.md
@@ -26,6 +26,7 @@
 ### 01. 下载安装 Jasminum 插件
 
 在 [茉莉花 - Zotero 插件商店](https://zotero-chinese.com/plugins/#search=jasminum) 下载 `.xpi` 文件，插件安装见 [插件与功能扩展](./about-plugin.md) 。
+
 在 [Zotero 插件商店](https://zotero-chinese.com/plugins/#search=Jasminum) 下载 `Jasminum` ，插件安装见 [插件与功能扩展](./about-plugin.md) 。
 
 ### 02. 配置 PDFtk
@@ -33,20 +34,14 @@
 #### 2.1 下载与安装 PDFtk
 
 **Windows**
-下载并安装 [PDFtk server](https://www.pdflabs.com/tools/pdftk-server/) ，记录安装路径（eg. `C: \Program Files (x86)\PDFtk`）。
+下载并安装 [PDFtk server](https://www.pdflabs.com/tools/pdftk-server/) ，并记录 PDFtk 的安装路径（例如安装在 `C: \Program Files (x86)\PDFtk`）。
 **macOS**
 MAC 用户参考 [这里](https://github.com/l0o0/jasminum#%E5%A6%82%E4%BD%95%E4%BD%BF%E7%94%A8) 。
 
 #### 2.2 在茉莉花中配置 PDFtk 路径
 
-在 Zotero——edit——Preferences——Jasminum——Setting——PDFtk Server Execute File Path 中填写 `<PDFtk install dir>/bin` （eg. `C: \Program Files (x86)\PDFtk\bin`）（即 PDFtk 可执行文件所在目录）。
+在 `Zotero` — `编辑` — `设置` — `茉莉花` — `PDFtk Server 路径设置` 中填写 `<PDFtk install dir>/bin` （例如 `C: \Program Files (x86)\PDFtk\bin`）（即 PDFtk 可执行文件所在目录）。
 
-### 03. 安装中文 Translator
+### 03. 安装/更新 中文 Translator
 
-与上一步同一界面——Unofficial Translator Repository——Refresh——Update all。
-
-### 04. 更新中文 Translator
-
-打开已安装 Zotero Connector 的浏览器，右击 Zotero Connector 图标进入拓展选项，Advanced——Update Translators。
-
-如果你打开了日志，则会看到绿色标出的提示。
+教程详见 [一键自动更新 Translator](../faqs/update-translators.md#更新抓取文献信息的转换器)

--- a/user-guide/plugins/jasminum.md
+++ b/user-guide/plugins/jasminum.md
@@ -44,4 +44,4 @@ MAC 用户参考 [这里](https://github.com/l0o0/jasminum#%E5%A6%82%E4%BD%95%E4
 
 ### 03. 安装/更新 中文 Translator
 
-教程详见 [一键自动更新 Translator](../faqs/update-translators.md#更新抓取文献信息的转换器)
+教程详见 [一键自动更新 Translator](../faqs/update-translators.md#更新抓取文献信息的转换器) 。


### PR DESCRIPTION
汉化“配置 PDFtk”术语；
删除“安装/更新 中文 Translator”中过期教程，并导航至“update-translators.md”