### PR TITLE
更新 ftp.linxingzhong.top 镜像地址

### DIFF
--- a/user-guide/install.md
+++ b/user-guide/install.md
@@ -67,7 +67,7 @@ Zotero 官方目前已开发有 iOS 客户端，在 App store 搜索下载 Zoter
 Zotero 官方现已发布 [Zotero for Android 测试版](https://forums.zotero.org/discussion/110371/available-for-beta-testing-zotero-for-android#latest)，然而，测试期间存在人数限制，且下载链接在 Google Play，国内下载不便，支持功能也有限，有条件的同学可以自行尝试。
 
 - [Google Play](https://play.google.com/store/apps/details?id=org.zotero.android)
-- [LingXingZhong 镜像](https://ftp.linxingzhong.top/Zotero_android/)
+- [LingXingZhong 镜像，APK 来源于下面源码编译仓库](https://ftp.linxingzhong.top/Zotero_for_Android/)
 
 我们也创建了一个仓库提供从源码编译的 Zotero Android 版本，见 [`northword/zotero-android-nightly-build`](https://github.com/northword/zotero-android-nightly-build) 仓库，但需注意，这个仓库发布的极不稳定，仅供测试使用！
 
@@ -76,5 +76,4 @@ Zotero 官方现已发布 [Zotero for Android 测试版](https://forums.zotero.o
 - Zoo for Zotero：
 
   - [Google Play](https://play.google.com/store/apps/details?id=com.mickstarify.zooforzotero)
-  - [LingXingZhong 镜像](https://ftp.linxingzhong.top/zooforzotero_43_apps.evozi.com.apk)
   - [Android Apps APK 镜像](https://androidappsapk.co/detail-zoo-for-zotero/)


### PR DESCRIPTION
因旧服务器未充值被销毁了，重新申请了一个机器。ftp 的目录结构有一些变化，删掉了原来保存的 zoo 客户端。目前来看zoo 客户端实在不如debug版本。