### PR TITLE
更新 wps-plugin.md 关于 Zotero 7 路径和 AppData 可见性的说明

### DIFF
--- a/user-guide/wps-plugin.md
+++ b/user-guide/wps-plugin.md
@@ -39,14 +39,33 @@ WPS 插件的按钮与 Word 插件类似，具体的操作过程，请参考 [�
 该部分教程来自与[官方文档](https://p.kdocs.cn/s/ZPIJCBAABE)
 
 若安装 Zotero 插件后，打开 WPS 不显示，请按照以下步骤操作：
+1.  **关闭 WPS Office 的所有程序**（如文字、表格、演示）。
 
-1. 关闭 WPS。
-2. 打开 Zotero 的安装包路径 `C:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install`
-3. 找到文件 Zotero.dotm，复制
-   ![image](../assets/images/WPS_Problems.png)
-4. 将第 3 步复制的文件粘贴到以下目录路径 `C:\Users\Administrator\AppData\Roaming\kingsoft\WPS\startup`
-   ![image](../assets/images/WPS_Problems-1.png)
-5. 重启 WPS，即可看到 Zotero 插件
+2.  **找到 Zotero.dotm 文件并复制它：**
+    *   **对于 Zotero 7 及更新版本：**
+        *   路径通常为： `[Zotero安装盘符]:\Program Files\Zotero\integration\word-for-windows\`
+        *   例如，如果您 Zotero 安装在 D 盘，路径则为 `D:\Program Files\Zotero\integration\word-for-windows\Zotero.dotm`
+        *   如果您 Zotero 安装在 C 盘，路径则为 `C:\Program Files\Zotero\integration\word-for-windows\Zotero.dotm`
+        *   **注意：** `Program Files` 也可能是 `Program Files (x86)`，取决于您的 Zotero 安装版本（32位或64位）和系统。请检查您的实际安装目录。
+    *   **对于 Zotero 6 及更早版本：**
+        *   路径通常为： `[Zotero安装盘符]:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install\`
+        *   例如：`C:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install\Zotero.dotm`
+    *   **如何找到 Zotero 安装目录？**
+        *   如果您不确定 Zotero 安装在哪里，可以尝试右键点击 Zotero 桌面快捷方式，选择“打开文件所在位置”来找到 Zotero 的主安装目录，然后根据您的 Zotero 版本进入上述相应的子文件夹。
+    *   在上述路径中找到 `Zotero.dotm` 文件后，选中它并按 `Ctrl+C` 复制。
+        ![image](../assets/images/WPS_Problems.png)
+
+3.  **将 Zotero.dotm 文件粘贴到 WPS 的启动 (startup) 文件夹：**
+    *   打开文件资源管理器，在地址栏输入以下路径并按回车键：
+        `%APPDATA%\kingsoft\wps\startup`
+        或者，您也可以手动导航到这个路径，它通常是：
+        `C:\Users\[您的用户名]\AppData\Roaming\kingsoft\wps\startup`
+        (请将 `[您的用户名]` 替换为您实际的 Windows 用户名，例如 `Administrator`, `YourName` 等。)
+    *   **注意：** `AppData` 文件夹默认是隐藏的。如果您在 `C:\Users\[您的用户名]\` 目录下看不到 `AppData` 文件夹，请在文件资源管理器的菜单栏中点击“查看”（或类似选项卡），然后在“显示/隐藏”区域勾选“隐藏的项目”（或类似选项）即可使其显示出来。
+        ![image](../assets/images/WPS_Problems-1.png)
+    *   在打开的 `startup` 文件夹内，按 `Ctrl+V` 粘贴刚刚复制的 `Zotero.dotm` 文件。
+
+4. *    重启 WPS，即可看到 Zotero 插件
    ![image](../assets/images/WPS_Problems-2.png)
 
 ### 3. 有多个 Zotero 选项卡

--- a/user-guide/wps-plugin.md
+++ b/user-guide/wps-plugin.md
@@ -39,34 +39,37 @@ WPS 插件的按钮与 Word 插件类似，具体的操作过程，请参考 [�
 该部分教程来自与[官方文档](https://p.kdocs.cn/s/ZPIJCBAABE)
 
 若安装 Zotero 插件后，打开 WPS 不显示，请按照以下步骤操作：
+
 1.  **关闭 WPS Office 的所有程序**（如文字、表格、演示）。
 
 2.  **找到 Zotero.dotm 文件并复制它：**
-    *   **对于 Zotero 7 及更新版本：**
-        *   路径通常为： `[Zotero安装盘符]:\Program Files\Zotero\integration\word-for-windows\`
-        *   例如，如果您 Zotero 安装在 D 盘，路径则为 `D:\Program Files\Zotero\integration\word-for-windows\Zotero.dotm`
-        *   如果您 Zotero 安装在 C 盘，路径则为 `C:\Program Files\Zotero\integration\word-for-windows\Zotero.dotm`
-        *   **注意：** `Program Files` 也可能是 `Program Files (x86)`，取决于您的 Zotero 安装版本（32位或64位）和系统。请检查您的实际安装目录。
-    *   **对于 Zotero 6 及更早版本：**
-        *   路径通常为： `[Zotero安装盘符]:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install\`
-        *   例如：`C:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install\Zotero.dotm`
-    *   **如何找到 Zotero 安装目录？**
-        *   如果您不确定 Zotero 安装在哪里，可以尝试右键点击 Zotero 桌面快捷方式，选择“打开文件所在位置”来找到 Zotero 的主安装目录，然后根据您的 Zotero 版本进入上述相应的子文件夹。
-    *   在上述路径中找到 `Zotero.dotm` 文件后，选中它并按 `Ctrl+C` 复制。
-        ![image](../assets/images/WPS_Problems.png)
+
+    - **对于 Zotero 7 及更新版本：**
+      - 路径通常为： `[Zotero安装盘符]:\Program Files\Zotero\integration\word-for-windows\`
+      - 例如，如果您 Zotero 安装在 D 盘，路径则为 `D:\Program Files\Zotero\integration\word-for-windows\Zotero.dotm`
+      - 如果您 Zotero 安装在 C 盘，路径则为 `C:\Program Files\Zotero\integration\word-for-windows\Zotero.dotm`
+      - **注意：** `Program Files` 也可能是 `Program Files (x86)`，取决于您的 Zotero 安装版本（32 位或 64 位）和系统。请检查您的实际安装目录。
+    - **对于 Zotero 6 及更早版本：**
+      - 路径通常为： `[Zotero安装盘符]:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install\`
+      - 例如：`C:\Program Files (x86)\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install\Zotero.dotm`
+    - **如何找到 Zotero 安装目录？**
+      - 如果您不确定 Zotero 安装在哪里，可以尝试右键点击 Zotero 桌面快捷方式，选择「打开文件所在位置」来找到 Zotero 的主安装目录，然后根据您的 Zotero 版本进入上述相应的子文件夹。
+    - 在上述路径中找到 `Zotero.dotm` 文件后，选中它并按 `Ctrl+C` 复制。
+      ![image](../assets/images/WPS_Problems.png)
 
 3.  **将 Zotero.dotm 文件粘贴到 WPS 的启动 (startup) 文件夹：**
-    *   打开文件资源管理器，在地址栏输入以下路径并按回车键：
-        `%APPDATA%\kingsoft\wps\startup`
-        或者，您也可以手动导航到这个路径，它通常是：
-        `C:\Users\[您的用户名]\AppData\Roaming\kingsoft\wps\startup`
-        (请将 `[您的用户名]` 替换为您实际的 Windows 用户名，例如 `Administrator`, `YourName` 等。)
-    *   **注意：** `AppData` 文件夹默认是隐藏的。如果您在 `C:\Users\[您的用户名]\` 目录下看不到 `AppData` 文件夹，请在文件资源管理器的菜单栏中点击“查看”（或类似选项卡），然后在“显示/隐藏”区域勾选“隐藏的项目”（或类似选项）即可使其显示出来。
-        ![image](../assets/images/WPS_Problems-1.png)
-    *   在打开的 `startup` 文件夹内，按 `Ctrl+V` 粘贴刚刚复制的 `Zotero.dotm` 文件。
 
-4. *    重启 WPS，即可看到 Zotero 插件
-   ![image](../assets/images/WPS_Problems-2.png)
+    - 打开文件资源管理器，在地址栏输入以下路径并按回车键：
+      `%APPDATA%\kingsoft\wps\startup`
+      或者，您也可以手动导航到这个路径，它通常是：
+      `C:\Users\[您的用户名]\AppData\Roaming\kingsoft\wps\startup`
+      (请将 `[您的用户名]` 替换为您实际的 Windows 用户名，例如 `Administrator`, `YourName` 等。)
+    - **注意：** `AppData` 文件夹默认是隐藏的。如果您在 `C:\Users\[您的用户名]\` 目录下看不到 `AppData` 文件夹，请在文件资源管理器的菜单栏中点击「查看」（或类似选项卡），然后在「显示/隐藏」区域勾选「隐藏的项目」（或类似选项）即可使其显示出来。
+      ![image](../assets/images/WPS_Problems-1.png)
+    - 在打开的 `startup` 文件夹内，按 `Ctrl+V` 粘贴刚刚复制的 `Zotero.dotm` 文件。
+
+4.  - 重启 WPS，即可看到 Zotero 插件
+      ![image](../assets/images/WPS_Problems-2.png)
 
 ### 3. 有多个 Zotero 选项卡
 


### PR DESCRIPTION
此 PR 更新了 wps-plugin.md 文件中关于在 WPS Office 中手动安装 Zotero 插件的指南。 解决的问题：
先前文档中关于 Zotero.dotm 文件定位的说明已过时，仍指向 Zotero 6 的路径。
文档未明确指出 Zotero 的实际安装盘符（如 C盘、D盘等）可能会因用户不同而有所差异。
文档缺少关于如何查看默认隐藏的 AppData 文件夹的必要提示，用户需要访问此文件夹下的 WPS 启动目录。